### PR TITLE
Refactor PRIVACY and TERMS to Goober.Cloud

### DIFF
--- a/PRIVACY
+++ b/PRIVACY
@@ -1,7 +1,7 @@
 Privacy Policy for Gamerbot
 Introduction
 
-Welcome to Gamerbot! This Privacy Policy explains how Gamerbot, a product of Goomba Labs, handles your data when you interact with our bot on Discord. Your privacy is important to us, and we are committed to protecting it.
+Welcome to Gamerbot! This Privacy Policy explains how Gamerbot, a product of Goober.Cloud, handles your data when you interact with our bot on Discord. Your privacy is important to us, and we are committed to protecting it.
 Data Collection and Use
 
 Gamerbot does not store any user data on its own servers. We do not collect, store, or share any personal information from users who interact with Gamerbot. All interactions with the bot occur within Discord's platform and are subject to Discord's privacy policies.
@@ -18,13 +18,13 @@ Data Security
 While Gamerbot does not store any user data, we are committed to ensuring that any data processed during interactions is handled securely. We utilize Discord's secure platform for all bot interactions.
 Changes to This Privacy Policy
 
-Goomba Labs may update this Privacy Policy from time to time. We will notify users of any changes by posting the new Privacy Policy on this page. You are advised to review this Privacy Policy periodically for any changes.
+Goober.Cloud may update this Privacy Policy from time to time. We will notify users of any changes by posting the new Privacy Policy on this page. You are advised to review this Privacy Policy periodically for any changes.
 Contact Us
 
 If you have any questions or concerns about this Privacy Policy, please contact us at:
 
-Goomba Labs
-Email: matt[at]xhec[dot]dev
+Goober.Cloud
+Email: matt[at]goober[dot]cloud
 
 By using Gamerbot, you agree to the terms outlined in this Privacy Policy.
 

--- a/TERMS
+++ b/TERMS
@@ -4,7 +4,7 @@ Last Updated: 6/26/2024
 
 1. Acceptance of Terms
 
-By accessing or using Gamerbot by Goomba Labs ("the Service"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, please do not use the Service.
+By accessing or using Gamerbot by Goober.Cloud ("the Service"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, please do not use the Service.
 
 2. Description of Service
 
@@ -25,7 +25,7 @@ You agree to use the Service only for lawful purposes and in a way that does not
 
 5. Intellectual Property
 
-All content provided on the Service, including but not limited to text, graphics, logos, and software, is the property of Goomba Labs and is protected by intellectual property laws. You may not use, reproduce, or distribute any content from the Service without our prior written permission.
+All content provided on the Service, including but not limited to text, graphics, logos, and software, is the property of Goober.Cloud and is protected by intellectual property laws. You may not use, reproduce, or distribute any content from the Service without our prior written permission.
 
 6. Privacy
 
@@ -33,7 +33,7 @@ Your privacy is important to us. Please refer to our Privacy Policy for informat
 
 7. Limitation of Liability
 
-To the fullest extent permitted by law, Goomba Labs and Gamerbot shall not be liable for any direct, indirect, incidental, special, or consequential damages resulting from the use or inability to use the Service, even if we have been advised of the possibility of such damages.
+To the fullest extent permitted by law, Goober.Cloud and Gamerbot shall not be liable for any direct, indirect, incidental, special, or consequential damages resulting from the use or inability to use the Service, even if we have been advised of the possibility of such damages.
 
 8. Changes to the Terms
 
@@ -49,4 +49,4 @@ These Terms shall be governed and construed in accordance with the laws of the U
 
 11. Contact Information
 
-If you have any questions about these Terms, please reach out to matt[at]xhec[dot]dev.
+If you have any questions about these Terms, please reach out to matt[at]goober[dot]cloud.


### PR DESCRIPTION
This PR refactors references in the Privacy Policy and Terms of Service from 'Goomba Labs' to 'Goober.Cloud' and updates the contact email to matt[at]goober[dot]cloud.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Privacy Policy and Terms of Service to reflect the company rebranding from Goomba Labs to Goober.Cloud.
  
- **Documentation**
	- Revised contact information in both documents to the new email address associated with Goober.Cloud.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->