### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -6,6 +6,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   creosote-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SomethingGeneric/GamerbotAgain/security/code-scanning/5](https://github.com/SomethingGeneric/GamerbotAgain/security/code-scanning/5)

The best way to fix the problem is to explicitly specify a minimal `permissions:` block in the workflow, limiting the GITHUB_TOKEN to only the access required. For this workflow, which performs only local checks and does not interact with the repository or create PRs/issues, the least privilege permission is `contents: read`. This can be set at the workflow level (directly after the `name:` and `on:` fields, before `jobs:`), so it applies by default to all jobs in this workflow. This fix requires only a single config change in `.github/workflows/packages.yml` and does not affect any job logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions to include read access to repository contents at the workflow level.
  * Standardizes permissions and aligns with GitHub security best practices.
  * No changes to job steps, triggers, or runtime behavior.
  * May reduce permission-related warnings or failures in CI tasks that read repository metadata.
  * No user-facing impact; application features and performance remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->